### PR TITLE
Upgrade to EPiServer.Commerce.Core.13

### DIFF
--- a/src/Geta.Bring.EPi.Commerce.Manager/Geta.Bring.EPi.Commerce.Manager.csproj
+++ b/src/Geta.Bring.EPi.Commerce.Manager/Geta.Bring.EPi.Commerce.Manager.csproj
@@ -47,7 +47,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AjaxControlToolkit, Version=3.0.30930.28736, Culture=neutral, PublicKeyToken=28f01b0e84b6d53e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\AjaxControlToolkit.dll</HintPath>
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\AjaxControlToolkit.dll</HintPath>
     </Reference>
     <Reference Include="AuthorizeNet, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AuthorizeNet.1.9.4\lib\AuthorizeNet.dll</HintPath>
@@ -58,53 +58,56 @@
     <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Windsor.4.1.0\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.dll</HintPath>
+    <Reference Include="EPiServer, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.11.1\lib\net461\EPiServer.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.ApplicationModules, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
+    <Reference Include="EPiServer.ApplicationModules, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Business.Commerce, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\EPiServer.Business.Commerce.dll</HintPath>
+    <Reference Include="EPiServer.Business.Commerce, Version=13.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\EPiServer.Business.Commerce.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Cms.AspNet, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Cms.AspNet, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Commerce.Internal.Migration, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\EPiServer.Commerce.Internal.Migration.dll</HintPath>
+    <Reference Include="EPiServer.Commerce.Internal.Migration, Version=13.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\EPiServer.Commerce.Internal.Migration.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Configuration, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Configuration.dll</HintPath>
+    <Reference Include="EPiServer.Commerce.Reporting, Version=13.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\EPiServer.Commerce.Reporting.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Data, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Data.dll</HintPath>
+    <Reference Include="EPiServer.Configuration, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Data.Cache, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Data.Cache.dll</HintPath>
+    <Reference Include="EPiServer.Data, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Data.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Enterprise, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.Enterprise.dll</HintPath>
+    <Reference Include="EPiServer.Data.Cache, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Data.Cache.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Events, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Events.dll</HintPath>
+    <Reference Include="EPiServer.Enterprise, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.11.1\lib\net461\EPiServer.Enterprise.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Framework, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Framework.dll</HintPath>
+    <Reference Include="EPiServer.Events, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Events.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Framework.AspNet, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.AspNet.11.4.0\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Framework, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.ImageLibrary, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
+    <Reference Include="EPiServer.Framework.AspNet, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.AspNet.11.11.1\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Licensing, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Licensing.dll</HintPath>
+    <Reference Include="EPiServer.ImageLibrary, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.LinkAnalyzer, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+    <Reference Include="EPiServer.Licensing, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Web.WebControls, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
+    <Reference Include="EPiServer.LinkAnalyzer, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.11.1\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+    </Reference>
+    <Reference Include="EPiServer.Web.WebControls, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
@@ -112,53 +115,50 @@
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.BusinessFoundation, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.BusinessFoundation.dll</HintPath>
+    <Reference Include="Mediachase.BusinessFoundation, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.BusinessFoundation.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.BusinessFoundation.Data, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.BusinessFoundation.Data.dll</HintPath>
+    <Reference Include="Mediachase.BusinessFoundation.Data, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.BusinessFoundation.Data.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.dll</HintPath>
+    <Reference Include="Mediachase.Commerce, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Marketing.Validators, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Marketing.Validators.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Plugins.Payment, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Plugins.Payment.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Plugins.Payment, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Plugins.Payment.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Plugins.Shipping, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Plugins.Shipping.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Plugins.Shipping, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Plugins.Shipping.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Website, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Website.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Website, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Website.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Workflow, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Workflow.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Workflow, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Workflow.dll</HintPath>
+    <Reference Include="Mediachase.DataProvider, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.DataProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.DataProvider, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.DataProvider.dll</HintPath>
+    <Reference Include="Mediachase.FileUploader, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.FileUploader.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.FileUploader, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.FileUploader.dll</HintPath>
+    <Reference Include="Mediachase.MetaDataPlus, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.MetaDataPlus.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.MetaDataPlus, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.MetaDataPlus.dll</HintPath>
+    <Reference Include="Mediachase.Search, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Search.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Search.dll</HintPath>
+    <Reference Include="Mediachase.Search.Extensions, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Search.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search.Extensions, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Search.Extensions.dll</HintPath>
+    <Reference Include="Mediachase.Search.LuceneSearchProvider, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Search.LuceneSearchProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search.LuceneSearchProvider, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Search.LuceneSearchProvider.dll</HintPath>
+    <Reference Include="Mediachase.SqlDataProvider, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.SqlDataProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.SqlDataProvider, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.SqlDataProvider.dll</HintPath>
-    </Reference>
-    <Reference Include="Mediachase.WebConsoleLib, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
+    <Reference Include="Mediachase.WebConsoleLib, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -208,6 +208,9 @@
       <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>

--- a/src/Geta.Bring.EPi.Commerce.Manager/app.config
+++ b/src/Geta.Bring.EPi.Commerce.Manager/app.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Framework" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Shell" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
@@ -15,15 +15,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Data" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Configuration" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.BaseLibrary" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
@@ -31,7 +31,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.ApplicationModules" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.XForms" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
@@ -39,11 +39,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.LinkAnalyzer" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Licensing" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.WorkflowFoundation" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
@@ -51,15 +51,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Web.WebControls" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Enterprise" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.ImageLibrary" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="StructureMap" publicKeyToken="e60ad81abae3c223" culture="neutral" />
@@ -75,7 +75,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Events" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
@@ -95,7 +95,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Data.Cache" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="AjaxControlToolkit" publicKeyToken="28f01b0e84b6d53e" culture="neutral" />
@@ -103,23 +103,23 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Business.Commerce" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Commerce.Internal.Migration" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.BusinessFoundation.Data" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.BusinessFoundation" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce" publicKeyToken="6e58b501b34abce3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Marketing.Validators" publicKeyToken="null" culture="neutral" />
@@ -127,51 +127,51 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Plugins.Payment" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Plugins.Shipping" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Website" publicKeyToken="6e58b501b34abce3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Workflow" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.DataProvider" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.FileUploader" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.MetaDataPlus" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Search" publicKeyToken="6e58b501b34abce3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Search.Extensions" publicKeyToken="6e58b501b34abce3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Search.LuceneSearchProvider" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.SqlDataProvider" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.WebConsoleLib" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -179,11 +179,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Cms.AspNet" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Framework.AspNet" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -197,7 +197,7 @@
         <assemblyIdentity name="EPiServer.ServiceLocation.StructureMap" publicKeyToken="null" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.0.0.0" newVersion="1.0.0.0" />
       </dependentAssembly>
-    </assemblyBinding>
+    <dependentAssembly><assemblyIdentity name="EPiServer.Commerce.Reporting" publicKeyToken="8fe83dea738b45b7" culture="neutral" /><bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" /></dependentAssembly></assemblyBinding>
   </runtime>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">

--- a/src/Geta.Bring.EPi.Commerce.Manager/packages.config
+++ b/src/Geta.Bring.EPi.Commerce.Manager/packages.config
@@ -3,11 +3,11 @@
   <package id="AuthorizeNet" version="1.9.4" targetFramework="net461" />
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="Castle.Windsor" version="4.1.0" targetFramework="net461" />
-  <package id="EPiServer.CMS.AspNet" version="11.4.0" targetFramework="net461" />
-  <package id="EPiServer.CMS.Core" version="11.4.0" targetFramework="net461" />
-  <package id="EPiServer.Commerce.Core" version="12.0.0" allowedVersions="[12,13)" targetFramework="net461" />
-  <package id="EPiServer.Framework" version="11.4.0" targetFramework="net461" />
-  <package id="EPiServer.Framework.AspNet" version="11.4.0" targetFramework="net461" />
+  <package id="EPiServer.CMS.AspNet" version="11.11.1" targetFramework="net461" />
+  <package id="EPiServer.CMS.Core" version="11.11.1" targetFramework="net461" />
+  <package id="EPiServer.Commerce.Core" version="13.0.0" allowedVersions="[13,14)" targetFramework="net461" />
+  <package id="EPiServer.Framework" version="11.11.1" targetFramework="net461" />
+  <package id="EPiServer.Framework.AspNet" version="11.11.1" targetFramework="net461" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
@@ -27,4 +27,5 @@
   <package id="System.Security.Permissions" version="4.4.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net461" />
   <package id="System.Threading.AccessControl" version="4.4.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/src/Geta.Bring.EPi.Commerce/Geta.Bring.EPi.Commerce.csproj
+++ b/src/Geta.Bring.EPi.Commerce/Geta.Bring.EPi.Commerce.csproj
@@ -47,7 +47,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AjaxControlToolkit, Version=3.0.30930.28736, Culture=neutral, PublicKeyToken=28f01b0e84b6d53e, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\AjaxControlToolkit.dll</HintPath>
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\AjaxControlToolkit.dll</HintPath>
     </Reference>
     <Reference Include="AuthorizeNet, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AuthorizeNet.1.9.4\lib\AuthorizeNet.dll</HintPath>
@@ -61,53 +61,56 @@
     <Reference Include="DotNetZip, Version=1.11.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
       <HintPath>..\..\packages\DotNetZip.1.11.0\lib\net20\DotNetZip.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.dll</HintPath>
+    <Reference Include="EPiServer, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.11.1\lib\net461\EPiServer.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.ApplicationModules, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
+    <Reference Include="EPiServer.ApplicationModules, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Business.Commerce, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\EPiServer.Business.Commerce.dll</HintPath>
+    <Reference Include="EPiServer.Business.Commerce, Version=13.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\EPiServer.Business.Commerce.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Cms.AspNet, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Cms.AspNet, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Commerce.Internal.Migration, Version=12.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\EPiServer.Commerce.Internal.Migration.dll</HintPath>
+    <Reference Include="EPiServer.Commerce.Internal.Migration, Version=13.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\EPiServer.Commerce.Internal.Migration.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Configuration, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Configuration.dll</HintPath>
+    <Reference Include="EPiServer.Commerce.Reporting, Version=13.0.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\EPiServer.Commerce.Reporting.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Data, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Data.dll</HintPath>
+    <Reference Include="EPiServer.Configuration, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Data.Cache, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Data.Cache.dll</HintPath>
+    <Reference Include="EPiServer.Data, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Data.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Enterprise, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.Enterprise.dll</HintPath>
+    <Reference Include="EPiServer.Data.Cache, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Data.Cache.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Events, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Events.dll</HintPath>
+    <Reference Include="EPiServer.Enterprise, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.11.1\lib\net461\EPiServer.Enterprise.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Framework, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Framework.dll</HintPath>
+    <Reference Include="EPiServer.Events, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Events.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Framework.AspNet, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.AspNet.11.4.0\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Framework, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.ImageLibrary, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
+    <Reference Include="EPiServer.Framework.AspNet, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.AspNet.11.11.1\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Licensing, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Licensing.dll</HintPath>
+    <Reference Include="EPiServer.ImageLibrary, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.LinkAnalyzer, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+    <Reference Include="EPiServer.Licensing, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Licensing.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer.Web.WebControls, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
+    <Reference Include="EPiServer.LinkAnalyzer, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.11.1\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+    </Reference>
+    <Reference Include="EPiServer.Web.WebControls, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=0.86.0.518, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
@@ -115,53 +118,50 @@
     <Reference Include="Lucene.Net, Version=3.0.3.0, Culture=neutral, PublicKeyToken=85089178b9ac3181, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Lucene.Net.3.0.3\lib\NET40\Lucene.Net.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.BusinessFoundation, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.BusinessFoundation.dll</HintPath>
+    <Reference Include="Mediachase.BusinessFoundation, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.BusinessFoundation.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.BusinessFoundation.Data, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.BusinessFoundation.Data.dll</HintPath>
+    <Reference Include="Mediachase.BusinessFoundation.Data, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.BusinessFoundation.Data.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.dll</HintPath>
+    <Reference Include="Mediachase.Commerce, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Marketing.Validators, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Marketing.Validators.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Plugins.Payment, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Plugins.Payment.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Plugins.Payment, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Plugins.Payment.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Plugins.Shipping, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Plugins.Shipping.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Plugins.Shipping, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Plugins.Shipping.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Website, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Website.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Website, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Website.dll</HintPath>
+    <Reference Include="Mediachase.Commerce.Workflow, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Commerce.Workflow.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Commerce.Workflow, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Commerce.Workflow.dll</HintPath>
+    <Reference Include="Mediachase.DataProvider, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.DataProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.DataProvider, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.DataProvider.dll</HintPath>
+    <Reference Include="Mediachase.FileUploader, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.FileUploader.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.FileUploader, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.FileUploader.dll</HintPath>
+    <Reference Include="Mediachase.MetaDataPlus, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.MetaDataPlus.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.MetaDataPlus, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.MetaDataPlus.dll</HintPath>
+    <Reference Include="Mediachase.Search, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Search.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Search.dll</HintPath>
+    <Reference Include="Mediachase.Search.Extensions, Version=13.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Search.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search.Extensions, Version=12.0.0.0, Culture=neutral, PublicKeyToken=6e58b501b34abce3, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Search.Extensions.dll</HintPath>
+    <Reference Include="Mediachase.Search.LuceneSearchProvider, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.Search.LuceneSearchProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.Search.LuceneSearchProvider, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.Search.LuceneSearchProvider.dll</HintPath>
+    <Reference Include="Mediachase.SqlDataProvider, Version=13.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.SqlDataProvider.dll</HintPath>
     </Reference>
-    <Reference Include="Mediachase.SqlDataProvider, Version=12.0.0.0, Culture=neutral, PublicKeyToken=41d2e7a615ba286c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.SqlDataProvider.dll</HintPath>
-    </Reference>
-    <Reference Include="Mediachase.WebConsoleLib, Version=12.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Commerce.Core.12.0.0\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
+    <Reference Include="Mediachase.WebConsoleLib, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EPiServer.Commerce.Core.13.0.0\lib\net461\Mediachase.WebConsoleLib.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -211,6 +211,9 @@
       <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>

--- a/src/Geta.Bring.EPi.Commerce/app.config
+++ b/src/Geta.Bring.EPi.Commerce/app.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Framework" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Shell" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
@@ -15,15 +15,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Data" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Configuration" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.BaseLibrary" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
@@ -31,7 +31,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.ApplicationModules" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.XForms" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
@@ -39,11 +39,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.LinkAnalyzer" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Licensing" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.WorkflowFoundation" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
@@ -51,15 +51,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Web.WebControls" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Enterprise" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.ImageLibrary" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
@@ -67,7 +67,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Events" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Castle.Windsor" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
@@ -95,23 +95,23 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Business.Commerce" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Commerce.Internal.Migration" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.BusinessFoundation.Data" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.BusinessFoundation" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce" publicKeyToken="6e58b501b34abce3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Marketing.Validators" publicKeyToken="null" culture="neutral" />
@@ -119,51 +119,51 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Plugins.Payment" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Plugins.Shipping" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Website" publicKeyToken="6e58b501b34abce3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Commerce.Workflow" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.DataProvider" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.FileUploader" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.MetaDataPlus" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Search" publicKeyToken="6e58b501b34abce3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Search.Extensions" publicKeyToken="6e58b501b34abce3" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.Search.LuceneSearchProvider" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.SqlDataProvider" publicKeyToken="41d2e7a615ba286c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Mediachase.WebConsoleLib" publicKeyToken="null" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -171,7 +171,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Data.Cache" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="StructureMap" publicKeyToken="e60ad81abae3c223" culture="neutral" />
@@ -179,11 +179,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Framework.AspNet" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.Cms.AspNet" publicKeyToken="8fe83dea738b45b7" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.4.0.0" newVersion="11.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-11.11.1.0" newVersion="11.11.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="EPiServer.ServiceLocation.StructureMap" publicKeyToken="null" culture="neutral" />
@@ -197,7 +197,7 @@
         <assemblyIdentity name="System.Web.Razor" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
       </dependentAssembly>
-    </assemblyBinding>
+    <dependentAssembly><assemblyIdentity name="EPiServer.Commerce.Reporting" publicKeyToken="8fe83dea738b45b7" culture="neutral" /><bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" /></dependentAssembly></assemblyBinding>
   </runtime>
   <entityFramework>
     <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">

--- a/src/Geta.Bring.EPi.Commerce/packages.config
+++ b/src/Geta.Bring.EPi.Commerce/packages.config
@@ -4,11 +4,11 @@
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="Castle.Windsor" version="4.1.0" targetFramework="net461" />
   <package id="DotNetZip" version="1.11.0" targetFramework="net461" />
-  <package id="EPiServer.CMS.AspNet" version="11.4.0" targetFramework="net461" />
-  <package id="EPiServer.CMS.Core" version="11.4.0" targetFramework="net461" />
-  <package id="EPiServer.Commerce.Core" version="12.0.0" allowedVersions="[12,13)" targetFramework="net461" />
-  <package id="EPiServer.Framework" version="11.4.0" targetFramework="net461" />
-  <package id="EPiServer.Framework.AspNet" version="11.4.0" targetFramework="net461" />
+  <package id="EPiServer.CMS.AspNet" version="11.11.1" targetFramework="net461" />
+  <package id="EPiServer.CMS.Core" version="11.11.1" targetFramework="net461" />
+  <package id="EPiServer.Commerce.Core" version="13.0.0" allowedVersions="[13,14)" targetFramework="net461" />
+  <package id="EPiServer.Framework" version="11.11.1" targetFramework="net461" />
+  <package id="EPiServer.Framework.AspNet" version="11.11.1" targetFramework="net461" />
   <package id="Lucene.Net" version="3.0.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
@@ -28,4 +28,5 @@
   <package id="System.Security.Permissions" version="4.4.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net461" />
   <package id="System.Threading.AccessControl" version="4.4.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>

--- a/src/Geta.Bring.Sample/Geta.Bring.Sample.csproj
+++ b/src/Geta.Bring.Sample/Geta.Bring.Sample.csproj
@@ -37,51 +37,66 @@
     <Reference Include="Castle.Windsor, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Windsor.4.1.0\lib\net45\Castle.Windsor.dll</HintPath>
     </Reference>
-    <Reference Include="EPiServer, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.dll</HintPath>
+    <Reference Include="EPiServer, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.11.1\lib\net461\EPiServer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.ApplicationModules, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
+    <Reference Include="EPiServer.ApplicationModules, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.ApplicationModules.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Cms.AspNet, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Cms.AspNet, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Cms.AspNet.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Configuration, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Configuration.dll</HintPath>
+    <Reference Include="EPiServer.Configuration, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Configuration.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Data, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Data.dll</HintPath>
+    <Reference Include="EPiServer.Data, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Data.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Data.Cache, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Data.Cache.dll</HintPath>
+    <Reference Include="EPiServer.Data.Cache, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Data.Cache.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Enterprise, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.Enterprise.dll</HintPath>
+    <Reference Include="EPiServer.Enterprise, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.11.1\lib\net461\EPiServer.Enterprise.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Events, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Events.dll</HintPath>
+    <Reference Include="EPiServer.Events, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Events.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Framework, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Framework.dll</HintPath>
+    <Reference Include="EPiServer.Framework, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Framework.AspNet, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.AspNet.11.4.0\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
+    <Reference Include="EPiServer.Framework.AspNet, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.AspNet.11.11.1\lib\net461\EPiServer.Framework.AspNet.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.ImageLibrary, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
+    <Reference Include="EPiServer.ImageLibrary, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.ImageLibrary.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Licensing, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.Framework.11.4.0\lib\net461\EPiServer.Licensing.dll</HintPath>
+    <Reference Include="EPiServer.Licensing, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.Framework.11.11.1\lib\net461\EPiServer.Licensing.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.LinkAnalyzer, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.Core.11.4.0\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+    <Reference Include="EPiServer.LinkAnalyzer, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.Core.11.11.1\lib\net461\EPiServer.LinkAnalyzer.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="EPiServer.Web.WebControls, Version=11.4.0.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.4.0\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
+    <Reference Include="EPiServer.Web.WebControls, Version=11.11.1.0, Culture=neutral, PublicKeyToken=8fe83dea738b45b7">
+      <HintPath>..\..\packages\EPiServer.CMS.AspNet.11.11.1\lib\net461\EPiServer.Web.WebControls.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -119,6 +134,10 @@
       <HintPath>..\..\packages\Microsoft.Tpl.Dataflow.4.5.24\lib\portable-net45+win8+wpa81\System.Threading.Tasks.Dataflow.dll</HintPath>
     </Reference>
     <Reference Include="System.Transactions" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
+      <HintPath>..\..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>

--- a/src/Geta.Bring.Sample/packages.config
+++ b/src/Geta.Bring.Sample/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net461" />
   <package id="Castle.Windsor" version="4.1.0" targetFramework="net461" />
-  <package id="EPiServer.CMS.AspNet" version="11.4.0" targetFramework="net461" />
-  <package id="EPiServer.CMS.Core" version="11.4.0" targetFramework="net461" />
-  <package id="EPiServer.Framework" version="11.4.0" targetFramework="net461" />
-  <package id="EPiServer.Framework.AspNet" version="11.4.0" targetFramework="net461" />
+  <package id="EPiServer.CMS.AspNet" version="11.11.1" targetFramework="net461" />
+  <package id="EPiServer.CMS.Core" version="11.11.1" targetFramework="net461" />
+  <package id="EPiServer.Framework" version="11.11.1" targetFramework="net461" />
+  <package id="EPiServer.Framework.AspNet" version="11.11.1" targetFramework="net461" />
   <package id="jQuery" version="1.4.4" targetFramework="net461" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net461" />
@@ -22,4 +22,5 @@
   <package id="System.Security.Permissions" version="4.4.0" targetFramework="net461" />
   <package id="System.Security.Principal.Windows" version="4.4.0" targetFramework="net461" />
   <package id="System.Threading.AccessControl" version="4.4.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Since we are using EPiServer.Commerce.Core 13 on the Byggmakker project, I upgraded the following projects:
Geta.Bring.EPi.Commerce
Geta.Bring.EPi.Commerce.Manager

Reference ticket:
https://getano.atlassian.net/browse/BYG-1125