### PR TITLE
Added some context to error messages.

### DIFF
--- a/src/Geta.Bring.EPi.Commerce/BringShippingGateway.cs
+++ b/src/Geta.Bring.EPi.Commerce/BringShippingGateway.cs
@@ -145,7 +145,7 @@ namespace Geta.Bring.EPi.Commerce
 
             foreach (var error in result.Errors)
             {
-                builder.Append(error);
+                builder.Append(error.ToString());
                 builder.AppendLine();
             }
 

--- a/src/Geta.Bring/Shipping/Model/Errors/FieldError.cs
+++ b/src/Geta.Bring/Shipping/Model/Errors/FieldError.cs
@@ -10,5 +10,10 @@
 
         public string Message { get; }
         public string Field { get;}
+
+        public override string ToString()
+        {
+            return Code + ": '" + Field + "' " + Message;
+        }
     }
 }

--- a/src/Geta.Bring/Shipping/Model/Errors/ProductError.cs
+++ b/src/Geta.Bring/Shipping/Model/Errors/ProductError.cs
@@ -11,5 +11,9 @@ namespace Geta.Bring.Shipping.Model.Errors
         }
 
         public string Description { get; set; }
+        public override string ToString()
+        {
+            return Code + ": " + Description;
+        }
     }
 }


### PR DESCRIPTION
Suggesting appending some additional contextual data to errors from estimates.

Will turn `WARN Foundation.Commerce.Order.Services.ShippingService: INVALID_ARGUMENT` Into
```
WARN Foundation.Commerce.Order.Services.ShippingService: INVALID_ARGUMENT: 'frompostalcode' must be a valid postal code in NORWAY
```